### PR TITLE
Add Dockerfiles for services

### DIFF
--- a/july3/data_ingestor/Dockerfile
+++ b/july3/data_ingestor/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-u", "data_ingestor/ingest.py"]

--- a/july3/docker-compose.yml
+++ b/july3/docker-compose.yml
@@ -9,31 +9,41 @@ services:
       - "6379:6379"
 
   data_ingestor:
-    build: ./data_ingestor
+    build:
+      context: .
+      dockerfile: ./data_ingestor/Dockerfile
     restart: always
     depends_on:
       - redis
 
   wallet_watcher:
-    build: ./wallet_watcher
+    build:
+      context: .
+      dockerfile: ./wallet_watcher/Dockerfile
     restart: always
     depends_on:
       - redis
 
   signal_engine:
-    build: ./signal_engine
+    build:
+      context: .
+      dockerfile: ./signal_engine/Dockerfile
     restart: always
     depends_on:
       - redis
 
   execution_engine:
-    build: ./execution_engine
+    build:
+      context: .
+      dockerfile: ./execution_engine/Dockerfile
     restart: always
     depends_on:
       - redis
 
   telegram_control:
-    build: ./telegram_control
+    build:
+      context: .
+      dockerfile: ./telegram_control/Dockerfile
     restart: always
     depends_on:
       - redis

--- a/july3/execution_engine/Dockerfile
+++ b/july3/execution_engine/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-u", "execution_engine/execute.py"]

--- a/july3/signal_engine/Dockerfile
+++ b/july3/signal_engine/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-u", "signal_engine/analyze.py"]

--- a/july3/telegram_control/Dockerfile
+++ b/july3/telegram_control/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-u", "telegram_control/telegram_bot.py"]

--- a/july3/wallet_watcher/Dockerfile
+++ b/july3/wallet_watcher/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python", "-u", "wallet_watcher/watcher.py"]


### PR DESCRIPTION
## Summary
- add Dockerfiles for data_ingestor, wallet_watcher, signal_engine, execution_engine and telegram_control
- update docker-compose.yml to reference these Dockerfiles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68768465d2c8832bb62b0ce29f3f5c81